### PR TITLE
1.3 'from future import url' doesn't work.

### DIFF
--- a/smart_load_tag/utils.py
+++ b/smart_load_tag/utils.py
@@ -22,7 +22,10 @@ def load(parser, lib, tag='*', name=None, namespace=None, app=None):
     try:
         lib_name = lib
         lib = Library()
-        module_lib = get_library(lib_name, app)
+        if app:
+            module_lib = get_library(app)
+        else:
+            module_lib = get_library(lib_name)
         lib.tags.update(module_lib.tags)
         lib.filters.update(module_lib.filters)
         if tag != '*':


### PR DESCRIPTION
Hello,

It seems that smart-load-tag doesn't play well with 1.3's `{% from future import url %}` tags.  

As far as I can tell, it's because of the ambiguity of the new syntax, and how it interacts with the smart-load-tag's conventions.

This pull fixes support with the 1.3 tag-style, but loses functionality.  I don't consider it a good fix, but without it, django admin (or any apps that use future urls) don't work.  I also try not to submit bugs without something useful as a pull :)

In any case, support for the future urls without losing functionality would be great.  For my limited uses (mostly I'm using smart-load-tag for its namespaced imports), this works well.

Thanks!
